### PR TITLE
Add a History Track Randomizer

### DIFF
--- a/PlayMe.Server/AutoPlay/TrackRandomizers/HistoryRandomizer.cs
+++ b/PlayMe.Server/AutoPlay/TrackRandomizers/HistoryRandomizer.cs
@@ -1,0 +1,40 @@
+﻿using PlayMe.Common.Model;
+using PlayMe.Data;
+using PlayMe.Plumbing.Diagnostics;
+using PlayMe.Server.AutoPlay.TrackRandomizers.Interfaces;
+using PlayMe.Server.Extensions;
+using System.Linq;
+
+namespace PlayMe.Server.AutoPlay.TrackRandomizers
+{
+    public class HistoryRandomizer : ITrackRandomizer
+    {
+        private readonly IDataService<QueuedTrack> queuedTrackDataService;
+        private readonly ILogger logger;
+
+        public HistoryRandomizer(IDataService<QueuedTrack> queuedTrackDataService, ILogger logger)
+        {
+            this.queuedTrackDataService = queuedTrackDataService;
+            this.logger = logger;
+        }
+
+        public int Version
+        {
+            get { return 4; }
+        }
+
+        public QueuedTrack Execute(QueuedTrack trackToQueue)
+        {
+            logger.Debug("HistoryRandomizer, {0}", trackToQueue.ToLoggerFriendlyTrackName());
+
+            var nextTrack = queuedTrackDataService.GetAll().Random().FirstOrDefault();
+
+            if (nextTrack != null)
+            {
+                return nextTrack;
+            }
+
+            return trackToQueue;
+        }
+    }
+}

--- a/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
+++ b/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
@@ -33,7 +33,8 @@ namespace PlayMe.Server.AutoPlay.TrackRandomizers
                     new PassThroughRandomizer(logger),
                     new OffSameAlbumRandomizer(musicProviderFactory, logger),
                     new SimilarArtistRandomizer(musicProviderFactory, logger),
-                    new OffArtistsAlbumRandomizer(musicProviderFactory, logger)
+                    new OffArtistsAlbumRandomizer(musicProviderFactory, logger),
+                    new HistoryRandomizer(queuedTrackDataService, logger)
                 };
         }
 

--- a/PlayMe.Server/PlayMe.Server.csproj
+++ b/PlayMe.Server/PlayMe.Server.csproj
@@ -121,6 +121,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutoPlay\TrackRandomizers\HistoryRandomizer.cs" />
     <Compile Include="Broadcast\Broadcasters\Twitter\ITwitterSettings.cs" />
     <Compile Include="Broadcast\Broadcasters\Twitter\TwitterSettings.cs" />
     <Compile Include="Broadcast\BroadcastMessageRuleResolver.cs" />


### PR DESCRIPTION
Added a new Track randomizer that chooses a random track form the history list.

Would be good to be able to use multiple track randomizers but that's another PR.