### PR TITLE
Use IdentityHelper Everywhere

### DIFF
--- a/PlayMe.Web/Controllers/AdminController.cs
+++ b/PlayMe.Web/Controllers/AdminController.cs
@@ -20,7 +20,8 @@ namespace PlayMe.Web.Controllers
                 Guid idGuid;
                 if (Guid.TryParse(id, out idGuid))
                 {
-                    client.SkipTrack(idGuid, User.Identity.Name);
+                    var identityHelper = new IdentityHelper();
+                    client.SkipTrack(idGuid, identityHelper.GetCurrentIdentityName());
                 }
             }
         }
@@ -30,7 +31,8 @@ namespace PlayMe.Web.Controllers
         {
             using (var client = new MusicServiceClient())
             {
-                return client.IsUserAdmin(User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                return client.IsUserAdmin(identityHelper.GetCurrentIdentityName());
             }
         }
         [HttpGet]
@@ -38,7 +40,8 @@ namespace PlayMe.Web.Controllers
         {
             using (var client = new MusicServiceClient())
             {
-                return client.IsUserSuperAdmin(User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                return client.IsUserSuperAdmin(identityHelper.GetCurrentIdentityName());
             }
         }
 
@@ -63,7 +66,8 @@ namespace PlayMe.Web.Controllers
                 var username = user.Username.Split('\\');
                 user.Username = username[0] + "\\" + username[1].ToLower();
 
-                return client.AddAdminUser(user, User.Identity.Name);    
+                var identityHelper = new IdentityHelper();
+                return client.AddAdminUser(user, identityHelper.GetCurrentIdentityName());    
             }
         }
 
@@ -77,9 +81,10 @@ namespace PlayMe.Web.Controllers
                     throw new HttpResponseException(new System.Net.Http.HttpResponseMessage(System.Net.HttpStatusCode.Unauthorized));
                 }
 
-                if (User.Identity.Name.ToLower() != user.Username.ToLower())
+                var identityHelper = new IdentityHelper();
+                if (identityHelper.GetCurrentIdentityName().ToLower() != user.Username.ToLower())
                 {
-                    client.RemoveAdminUser(user.Username, User.Identity.Name);
+                    client.RemoveAdminUser(user.Username, identityHelper.GetCurrentIdentityName());
                     return true;
                 }
                 return false;

--- a/PlayMe.Web/Controllers/BrowseController.cs
+++ b/PlayMe.Web/Controllers/BrowseController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Web.Http;
 using PlayMe.Common.Model;
 using PlayMe.Web.MusicServiceReference;
+using PlayMe.Web.Code;
 
 namespace PlayMe.Web.Controllers
 {
@@ -21,7 +22,8 @@ namespace PlayMe.Web.Controllers
         {
             using (var client = new MusicServiceClient())
             {
-                return client.BrowseAlbum(id, provider, User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                return client.BrowseAlbum(id, provider, identityHelper.GetCurrentIdentityName());
             }
         }
 

--- a/PlayMe.Web/Controllers/LikesController.cs
+++ b/PlayMe.Web/Controllers/LikesController.cs
@@ -18,7 +18,7 @@ namespace PlayMe.Web.Controllers
                 if (Guid.TryParse(id, out idGuid))
                 {
                     var identityHelper = new IdentityHelper();
-                    //client.LikeTrack(idGuid, identityHelper.GetCurrentIdentityName());
+                    client.LikeTrack(idGuid, identityHelper.GetCurrentIdentityName());
                 }
             }
         }

--- a/PlayMe.Web/Controllers/QueueController.cs
+++ b/PlayMe.Web/Controllers/QueueController.cs
@@ -17,7 +17,8 @@ namespace PlayMe.Web.Controllers
             string id = trackToQueue.id;
             string provider = trackToQueue.provider;
             string reason = trackToQueue.reason;
-            var user = User.Identity.Name;
+            var identityHelper = new IdentityHelper();
+            var user = identityHelper.GetCurrentIdentityName();
             using (var client = new MusicServiceClient())
             {
                 var track = client.GetTrack(id, provider, user);

--- a/PlayMe.Web/Controllers/SearchController.cs
+++ b/PlayMe.Web/Controllers/SearchController.cs
@@ -2,6 +2,7 @@
 using System.Web.Http;
 using PlayMe.Common.Model;
 using PlayMe.Web.MusicServiceReference;
+using PlayMe.Web.Code;
 
 namespace PlayMe.Web.Controllers
 {
@@ -12,7 +13,8 @@ namespace PlayMe.Web.Controllers
         {
             using (var client = new MusicServiceClient())
             {
-                return client.SearchAll(searchTerm, provider, User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                return client.SearchAll(searchTerm, provider, identityHelper.GetCurrentIdentityName());
             }
         }
 

--- a/PlayMe.Web/Hubs/QueueHub.cs
+++ b/PlayMe.Web/Hubs/QueueHub.cs
@@ -119,7 +119,8 @@ namespace PlayMe.Web.Hubs
         {
             using (var client = new MusicServiceClient())
             {
-                client.ResumeTrack(HttpContext.Current.User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                client.ResumeTrack(identityHelper.GetCurrentIdentityName());
                 Clients.All.updateCurrentTrack(client.GetPlayingTrack());
             }
         }
@@ -136,7 +137,8 @@ namespace PlayMe.Web.Hubs
         {
             using (var client = new MusicServiceClient())
             {
-                client.IncreaseVolume(HttpContext.Current.User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                client.IncreaseVolume(identityHelper.GetCurrentIdentityName());
                 Clients.All.updateCurrentVolume(client.GetCurrentVolume());
             }
         }
@@ -145,7 +147,8 @@ namespace PlayMe.Web.Hubs
         {
             using (var client = new MusicServiceClient())
             {
-                client.DecreaseVolume(HttpContext.Current.User.Identity.Name);
+                var identityHelper = new IdentityHelper();
+                client.DecreaseVolume(identityHelper.GetCurrentIdentityName());
                 Clients.All.updateCurrentVolume(client.GetCurrentVolume());
             }
         }


### PR DESCRIPTION
Replace Instances of `User.Identity.Name` with `IdentityHelper().GetCurrentIdentityName()` so later we can replace Identity providers.