### PR TITLE
Allow Multiple randomizers

### DIFF
--- a/PlayMe.Server/App.config
+++ b/PlayMe.Server/App.config
@@ -32,6 +32,7 @@
     <add key="MinAutoplayableTracks" value="3" />
     <add key="VetoCount" value="3" />
     <add key="Randomizer" value="0" />
+    <add key="Randomizers" value="0;1;2;3" />
     <add key="RandomizerRatio" value="10" />
     <add key="DontRepeatTrackForHours" value="0" />
     <add key="MusicService.AutoStart" value="true" />

--- a/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
+++ b/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
@@ -5,6 +5,7 @@ using PlayMe.Data;
 using PlayMe.Plumbing.Diagnostics;
 using PlayMe.Server.AutoPlay.TrackRandomizers.Interfaces;
 using PlayMe.Server.Providers;
+using PlayMe.Server.Extensions;
 
 namespace PlayMe.Server.AutoPlay.TrackRandomizers
 {
@@ -39,7 +40,7 @@ namespace PlayMe.Server.AutoPlay.TrackRandomizers
 
         public ITrackRandomizer Randomize
         {
-            get { return randomizers.FirstOrDefault(p => p.Version == settings.Randomizer); }
+            get { return randomizers.Where(p => settings.Randomizers.Contains(p.Version)).Random().FirstOrDefault(); }
         }
     }
 }

--- a/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
+++ b/PlayMe.Server/AutoPlay/TrackRandomizers/RandomizerFactory.cs
@@ -40,7 +40,14 @@ namespace PlayMe.Server.AutoPlay.TrackRandomizers
 
         public ITrackRandomizer Randomize
         {
-            get { return randomizers.Where(p => settings.Randomizers.Contains(p.Version)).Random().FirstOrDefault(); }
+            get
+            {
+                if (settings.Randomizers.Any())
+                {
+                    return randomizers.Where(p => settings.Randomizers.Contains(p.Version)).Random().FirstOrDefault();
+                }
+                return randomizers.FirstOrDefault(p => settings.Randomizer == p.Version);
+            }
         }
     }
 }

--- a/PlayMe.Server/ISettings.cs
+++ b/PlayMe.Server/ISettings.cs
@@ -1,4 +1,6 @@
-﻿namespace PlayMe.Server
+﻿using System.Collections.Generic;
+
+namespace PlayMe.Server
 {
     public interface ISettings
     {
@@ -7,6 +9,7 @@
         int MaxAutoplayableTracks { get; }
         int VetoCount { get; }
         int Randomizer { get; }
+        List<int> Randomizers { get; }
         int RandomizerRatio { get; }
         decimal RandomWeighting { get; }
         int DontRepeatTrackForHours { get; }

--- a/PlayMe.Server/Settings.cs
+++ b/PlayMe.Server/Settings.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Configuration;
+using System.Linq;
 
 namespace PlayMe.Server
 {
@@ -39,6 +41,15 @@ namespace PlayMe.Server
         public int Randomizer
         {
             get { return Convert.ToInt32(ConfigurationManager.AppSettings["Randomizer"]); }
+        }
+
+        public List<int> Randomizers
+        {
+            get
+            {
+                return ConfigurationManager.AppSettings["Randomizers"].Split(';')
+                       .Select(r => Convert.ToInt32(r)).ToList();
+            }
         }
 
         public int RandomizerRatio


### PR DESCRIPTION
This gives the ability for PlayMe.Server to randomly select a TrackRandomizer from a list specified in app.config as semicolon separated list of numbers.

`<add key="Randomizers" value="0;1;2;3" />`

Wasn't sure if we should replace the current setting or allow this one as well, so I went with allowing both.
